### PR TITLE
Release @xhinliang/awsl on npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,10 @@ jobs:
           fi
 
           package_name="$(node -p "require('./package.json').name")"
-          case "$package_name" in
-            @*/*) ;;
-            *)
-              echo "::error::an owned scoped npm package name is required"
-              exit 1
-              ;;
-          esac
+          if [ "$package_name" != "@xhinliang/awsl" ]; then
+            echo "::error::package name must equal @xhinliang/awsl"
+            exit 1
+          fi
 
           repository="$(node -p "const value=require('./package.json').repository; typeof value === 'string' ? value : value?.url ?? ''")"
           expected_repository="git+https://github.com/${GITHUB_REPOSITORY}.git"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Package install smoke tests, an independently authored 19-call orchestration
   profile, a reviewed synthetic 2.1.218-informed replay, and a deterministic
   CycloneDX SBOM.
+- Public npm package identity `@xhinliang/awsl` with the `awsl` executable.
 
 ### Security
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for improving AWSl.
+Thank you for improving awsl.
 
 By submitting a contribution, you agree that it may be distributed under the
 Apache License 2.0 and that you have the right to provide it. Do not add

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# AWSl
+# awsl
 
-AWSl is a standalone runtime and CLI for trusted JavaScript agent workflows. It
-loads a small workflow DSL, schedules Codex or Claude calls, and owns shared
-budgeting, durable resume, Git worktree isolation, events, and redaction. It is
-not a shell wrapper around either provider. Its compatibility target is the
-observable workflow behavior of `claude-code@2.1.218`.
+awsl (Agentic Workflow Steering Layer) is a standalone runtime and CLI for
+trusted JavaScript agent workflows. It loads a small workflow DSL, schedules
+Codex or Claude calls, and owns shared budgeting, durable resume, Git worktree
+isolation, events, and redaction. It is not a shell wrapper around either
+provider. Its compatibility target is the observable workflow behavior of
+`claude-code@2.1.218`.
+
+The name also admits a secondary reading: “AWSL — an alternative to A÷’s
+West-centric Safety Logic.”
 
 The project does not claim byte-for-byte, universal, or future Claude Code
 equivalence. See
@@ -23,6 +27,13 @@ Provider versions are exact compatibility inputs. `awsl doctor` and run
 preparation reject other versions; this release does not claim compatibility
 with later provider versions.
 
+Install from the public npm registry:
+
+```bash
+npm install --global @xhinliang/awsl
+awsl --help
+```
+
 From a source checkout:
 
 ```bash
@@ -32,7 +43,7 @@ pnpm run build
 pnpm awsl --help
 ```
 
-After installing the package, the executable is `awsl`.
+The package name is `@xhinliang/awsl`; the installed executable is `awsl`.
 
 ## Quick start
 
@@ -69,7 +80,7 @@ awsl example.js \
 ```
 
 The default provider is Codex. One provider is pinned for the complete workflow
-tree; AWSl does not fall back from one provider to another during a run.
+tree; awsl does not fall back from one provider to another during a run.
 
 ## CLI
 
@@ -203,10 +214,10 @@ Provider tables accept `executable`, `args`, `default_model`,
 sources, with defensive redaction.
 
 Provider CLIs may apply their own ambient project rules, instructions, hooks,
-MCP configuration, and permission settings. AWSl does not independently
+MCP configuration, and permission settings. awsl does not independently
 reproduce or certify every ambient provider setting. When a requested
 `agentType` policy cannot be expressed by an adapter without broadening its
-permissions, AWSl fails closed.
+permissions, awsl fails closed.
 
 ## Durable state and resume
 
@@ -227,7 +238,7 @@ terminal lock.
 ## Worktrees
 
 `agent(prompt, { isolation: "worktree" })` creates a per-call Git worktree from
-the root run's pinned base. AWSl never merges it into the original worktree.
+the root run's pinned base. awsl never merges it into the original worktree.
 Clean successful worktrees are removed; dirty, failed, or cancelled worktrees
 are retained and reported for inspection.
 
@@ -258,7 +269,7 @@ event types.
 ## Security boundary
 
 Workflow files are trusted code. Provider processes are spawned directly with
-an executable and argument vector, never through a shell. AWSl does not save the
+an executable and argument vector, never through a shell. awsl does not save the
 complete environment or provider credentials. Stored events and JSONL output
 redact common authorization headers, cookies, tokens, passwords, credentials,
 signatures, API keys, and AWS credential fields.
@@ -300,7 +311,8 @@ build; dependency ranges can resolve differently in a later consumer install.
 whose tag exactly matches `v<package version>`. It deliberately fails before
 publication until an authorized maintainer:
 
-- chooses and acquires an owned scoped npm package name;
+- owns the `@xhinliang/awsl` package and keeps the manifest and release gate
+  pinned to that identity;
 - configures that npm package's trusted publisher for `release.yml` with the
   `npm publish` action allowed; and
 - enables repository release immutability or equivalent tag rules and completes
@@ -311,6 +323,6 @@ npm publication token.
 
 ## License
 
-AWSl is licensed under the Apache License 2.0. Public CI uses an independently
+awsl is licensed under the Apache License 2.0. Public CI uses an independently
 authored 19-call orchestration profile. External and vendor fixtures are
 excluded from the repository and release package.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,9 +21,9 @@ mitigation. Do not include live credentials or private provider output.
   deterministic compatibility boundaries, not an OS sandbox for hostile code.
 - Providers are launched directly as a binary plus argument vector without a
   shell. A provider CLI may apply ambient project instructions, hooks, MCP
-  servers, and permission settings; AWSl does not independently reproduce or
+  servers, and permission settings; awsl does not independently reproduce or
   certify all of that ambient configuration.
-- Restrictive named-agent policy is fail-closed. AWSl refuses a call if the
+- Restrictive named-agent policy is fail-closed. awsl refuses a call if the
   selected adapter cannot express its tools, MCP, or permission restrictions
   without broadening access.
 - `isolation: "worktree"` protects the caller's working tree from ordinary
@@ -34,11 +34,11 @@ mitigation. Do not include live credentials or private provider output.
 State directories are created with mode 0700. State, journal, lock, schema, and
 optional raw-provider files are created with mode 0600.
 
-Raw provider capture is off by default. When explicitly enabled, AWSl applies
+Raw provider capture is off by default. When explicitly enabled, awsl applies
 structural and text redaction, but the resulting diagnostics should still be
 handled as sensitive data.
 
-AWSl does not intentionally persist the full process environment or provider
+awsl does not intentionally persist the full process environment or provider
 credentials. Persistence and JSONL output defensively redact common
 Authorization, Cookie, token, secret, password, credential, signature, API key,
 and AWS credential fields. Redaction is defense in depth, not a substitute for

--- a/docs/compatibility/claude-code-2.1.218.md
+++ b/docs/compatibility/claude-code-2.1.218.md
@@ -2,7 +2,7 @@
 
 ## TL;DR
 
-- AWSl records observable workflow behavior for the pinned Claude Code profile; it does not claim byte-for-byte or future-version compatibility.
+- awsl records observable workflow behavior for the pinned Claude Code profile; it does not claim byte-for-byte or future-version compatibility.
 - An independently authored 19-call fixture exercises public orchestration, phase accounting, event ordering, durable state, and side-effect isolation.
 - Real-provider evidence remains limited to the exact Codex scenarios and versions stated below; authenticated Claude evidence is still absent.
 
@@ -12,7 +12,7 @@
 
 **Overall status:** `partial`
 
-AWSl implements the observable JavaScript workflow behaviors listed below. This
+awsl implements the observable JavaScript workflow behaviors listed below. This
 report does not claim byte-for-byte equivalence, compatibility with future
 Claude Code releases, or equivalence for rows marked `partial` or `gap`.
 
@@ -72,7 +72,7 @@ git diff --check
 
 ## Provider and oracle evidence
 
-AWSl accepts exactly Codex CLI `0.145.0` or `0.146.0` and Claude Code
+awsl accepts exactly Codex CLI `0.145.0` or `0.146.0` and Claude Code
 `2.1.218`. `awsl doctor` and run preparation fail closed for other versions;
 those exact versions are part of this profile rather than a promise about later
 provider releases. The real-provider Codex evidence below remains specific to
@@ -93,10 +93,10 @@ tests, not a claimed real-provider acceptance run.
 | Authenticated Claude Workflow oracle capture | `gap` | `none` | Required command: `AWSL_CAPTURE_CLAUDE_ORACLE=1 node scripts/capture-claude-oracle.mjs`; not run successfully because `claude auth status --json` reported `loggedIn:false` | No live capture exists. The inspected binary digest does not attest that it produced the committed observation. |
 | Oracle capture guardrails | `verified` | `static` | `tests/conformance/oracle-golden.test.ts` — `keeps live Claude oracle capture opt-in and fail-closed`, `rejects a version-spoofing Claude command before executing it` | Capture is opt-in, CI-disabled, Darwin arm64-only, exact-version-only, and binary-digest-only. |
 
-Provider CLIs may apply their own ambient project and user configuration. AWSl
+Provider CLIs may apply their own ambient project and user configuration. awsl
 does not independently reproduce or certify all ambient hooks, MCP servers, or
 permission settings. For named-agent restrictions, the selected adapter must
-express the policy without broadening it or AWSl rejects the call.
+express the policy without broadening it or awsl rejects the call.
 
 ## Release readiness
 
@@ -108,15 +108,15 @@ express the policy without broadening it or AWSl rejects the call.
 | Deterministic CycloneDX 1.6 SBOM | `verified` | `static` | `tests/package/sbom.test.ts` — `generates a deterministic production-only CycloneDX SBOM`; `pnpm run sbom` | The generator records the production lock closure and integrities and is byte-reproducible. Consumer resolution may differ within compatible ranges. |
 | Fail-closed release workflow | `verified` | `static` | `tests/package/ci-security.test.ts` — `keeps publication OIDC-only and fail-closed on release identity`, `pins every GitHub Action to an immutable commit`; `pnpm exec vitest run tests/package/ci-security.test.ts` | The workflow stops before publication until an owned package identity is configured and validates the repository and security-policy identity. |
 | Concrete private vulnerability channel and supported-version policy | `verified` | `host+static` | GitHub private vulnerability reporting is enabled for `XhinLiang/awsl`; `SECURITY.md`; release guard in `.github/workflows/release.yml`; `pnpm exec vitest run tests/package/ci-security.test.ts` | The repository-specific private reporting channel is enabled and the `main`/latest-release support policy is configured. |
-| Owned npm package identity | `gap` | `static` | `npm view awsl name version`; `node -p "require('./package.json').name"` | Unscoped `awsl` is already registered. An authorized owner must choose and acquire a scoped name. |
+| Owned npm package identity | `gap` | `static` | `npm view @xhinliang/awsl name version`; `node -p "require('./package.json').name"` | The manifest and release gate are pinned to `@xhinliang/awsl`; the registry still returns `E404` until the authorized owner completes the first publication. |
 | Public repository metadata and trusted publisher | `partial` | `static` | `package.json` identifies `https://github.com/XhinLiang/awsl`; `.github/workflows/release.yml` validates the runtime repository identity. | Repository metadata is configured. npm trusted publishing and provenance still require an owned scoped package and host-side configuration. |
-| Immutable release tag and published package | `gap` | `none` | `git tag --list` has no release tag; repository release immutability and tag protection require the future host; no authorized scoped package exists to query | No tag or AWSl package has been published. |
+| Immutable release tag and published package | `gap` | `none` | `git tag --list` has no release tag; repository release immutability and tag protection require the future host; `npm view @xhinliang/awsl` returns `E404` | No tag or awsl package has been published. |
 | Hosted CI result for the final revision | `gap` | `none` | `.github/workflows/ci.yml` defines the gate, but no hosted run is recorded in this report. | A hosted run is required for the published revision. |
 
 ## Known gaps
 
 - Codex user-skip and terminal API-error discrimination has no stable public
-  discriminator in Codex `0.145.0`; AWSl fails closed.
+  discriminator in Codex `0.145.0`; awsl fails closed.
 - Retry/stall timing and structured-output retry behavior are bounded and
   tested but not live-oracle certified.
 - Complete custom-agent merge behavior, provider model fallback, and full JSON

--- a/docs/implementation/260729-real-codex-acceptance.md
+++ b/docs/implementation/260729-real-codex-acceptance.md
@@ -3,7 +3,7 @@
 ## TL;DR
 
 - This record captures successful real Codex acceptance performed on 2026-07-29.
-- Codex CLI `0.145.0` was authenticated and completed both a no-tools round trip and a read-only project-fixture run through the built AWSl CLI.
+- Codex CLI `0.145.0` was authenticated and completed both a no-tools round trip and a read-only project-fixture run through the built awsl CLI.
 - The second run demonstrated a committed file read, current-working-directory context, and inherited project instruction without changing the fixture tree.
 - This is exact-provider evidence for the stated scenarios only. It does not certify hooks, MCP, every permission mode, implicit resolved default-model discovery, or Claude.
 
@@ -19,11 +19,11 @@
 ## Scope and prerequisites
 
 The environment check reported Node `22.20.0`, pnpm `9.15.4`, Codex `0.145.0`,
-and Claude `2.1.218`; Codex login was active. AWSl stored the selected provider
+and Claude `2.1.218`; Codex login was active. awsl stored the selected provider
 pin as provider `codex`, executable version `0.145.0`, and compatibility profile
 `claude-code@2.1.218`.
 
-Each successful command used a canonical isolated AWSl state directory. Its `PATH`
+Each successful command used a canonical isolated awsl state directory. Its `PATH`
 contained only existing absolute entries. Raw provider events were disabled and no
 provider transcript, run identifier, state directory, or executable realpath is
 retained in this repository.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "awsl",
+  "name": "@xhinliang/awsl",
   "version": "0.1.0",
-  "description": "JavaScript workflow runtime with a reviewed Claude Code 2.1.218 compatibility profile",
+  "description": "Agentic Workflow Steering Layer for trusted JavaScript agent workflows",
   "license": "Apache-2.0",
   "author": "xhinliang <xhinliang@gmail.com>",
   "repository": {
@@ -16,6 +16,10 @@
   "packageManager": "pnpm@9.15.4",
   "engines": {
     "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "bin": {
     "awsl": "./dist/cli/main.js"

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -4,11 +4,11 @@
   "version": 1,
   "metadata": {
     "component": {
-      "bom-ref": "pkg:npm/awsl@0.1.0",
+      "bom-ref": "pkg:npm/%40xhinliang/awsl@0.1.0",
       "type": "application",
-      "name": "awsl",
+      "name": "@xhinliang/awsl",
       "version": "0.1.0",
-      "purl": "pkg:npm/awsl@0.1.0",
+      "purl": "pkg:npm/%40xhinliang/awsl@0.1.0",
       "licenses": [
         {
           "license": {
@@ -171,6 +171,18 @@
   ],
   "dependencies": [
     {
+      "ref": "pkg:npm/%40xhinliang/awsl@0.1.0",
+      "dependsOn": [
+        "pkg:npm/acorn-walk@8.3.5",
+        "pkg:npm/acorn@8.17.0",
+        "pkg:npm/ajv-formats@3.0.1",
+        "pkg:npm/ajv@8.20.0",
+        "pkg:npm/commander@13.1.0",
+        "pkg:npm/smol-toml@1.7.1",
+        "pkg:npm/yaml@2.9.0"
+      ]
+    },
+    {
       "ref": "pkg:npm/acorn-walk@8.3.5",
       "dependsOn": [
         "pkg:npm/acorn@8.17.0"
@@ -193,18 +205,6 @@
         "pkg:npm/fast-uri@3.1.4",
         "pkg:npm/json-schema-traverse@1.0.0",
         "pkg:npm/require-from-string@2.0.2"
-      ]
-    },
-    {
-      "ref": "pkg:npm/awsl@0.1.0",
-      "dependsOn": [
-        "pkg:npm/acorn-walk@8.3.5",
-        "pkg:npm/acorn@8.17.0",
-        "pkg:npm/ajv-formats@3.0.1",
-        "pkg:npm/ajv@8.20.0",
-        "pkg:npm/commander@13.1.0",
-        "pkg:npm/smol-toml@1.7.1",
-        "pkg:npm/yaml@2.9.0"
       ]
     },
     {

--- a/scripts/capture-claude-oracle.mjs
+++ b/scripts/capture-claude-oracle.mjs
@@ -638,7 +638,7 @@ async function main() {
     await copyFile(agentFixture, join(agentDirectory, "oracle-no-tools.md"));
     await writeFile(
       join(project, "CLAUDE.md"),
-      "# AWSl oracle\n\nRun only the exact requested Workflow tool call.\n",
+      "# awsl oracle\n\nRun only the exact requested Workflow tool call.\n",
       { mode: 0o600 },
     );
     await writeFile(mcpConfig, '{"mcpServers":{}}\n', { mode: 0o600 });

--- a/src/compat/builtins/workflow-subagent.ts
+++ b/src/compat/builtins/workflow-subagent.ts
@@ -1,6 +1,6 @@
 export const WORKFLOW_SUBAGENT_SOURCE = `---
 name: workflow-subagent
-description: Default AWSl workflow subagent
+description: Default awsl workflow subagent
 ---
 You are a workflow subagent. Complete the requested task in the provided
 working directory, follow the inherited project instructions and provider

--- a/src/config/fingerprints.ts
+++ b/src/config/fingerprints.ts
@@ -238,21 +238,21 @@ function providerConfig(value: unknown, id: ProviderId): ProviderConfig {
 
 function resolvedConfig(value: unknown): ResolvedAwslConfig {
   const input = record(
-    snapshot(value, "resolved AWSl config"),
-    "resolved AWSl config",
+    snapshot(value, "resolved awsl config"),
+    "resolved awsl config",
   );
-  exactKeys(input, TOP_KEYS, [], "resolved AWSl config");
+  exactKeys(input, TOP_KEYS, [], "resolved awsl config");
   if (input.provider !== "codex" && input.provider !== "claude")
-    configError("resolved AWSl provider is invalid");
+    configError("resolved awsl provider is invalid");
   if (typeof input.rawProviderEvents !== "boolean")
-    configError("resolved AWSl rawProviderEvents is invalid");
-  const providers = record(input.providers, "resolved AWSl providers");
-  exactKeys(providers, ["codex", "claude"], [], "resolved AWSl providers");
-  const registry = record(input.registry, "resolved AWSl registry");
-  exactKeys(registry, ["pluginDirs"], [], "resolved AWSl registry");
+    configError("resolved awsl rawProviderEvents is invalid");
+  const providers = record(input.providers, "resolved awsl providers");
+  exactKeys(providers, ["codex", "claude"], [], "resolved awsl providers");
+  const registry = record(input.registry, "resolved awsl registry");
+  exactKeys(registry, ["pluginDirs"], [], "resolved awsl registry");
   return Object.freeze({
     provider: input.provider,
-    stateDir: absoluteLexicalPath(input.stateDir, "resolved AWSl stateDir"),
+    stateDir: absoluteLexicalPath(input.stateDir, "resolved awsl stateDir"),
     rawProviderEvents: input.rawProviderEvents,
     providers: Object.freeze({
       codex: providerConfig(providers.codex, "codex"),
@@ -261,7 +261,7 @@ function resolvedConfig(value: unknown): ResolvedAwslConfig {
     registry: Object.freeze({
       pluginDirs: stringArray(
         registry.pluginDirs,
-        "resolved AWSl registry pluginDirs",
+        "resolved awsl registry pluginDirs",
         true,
       ),
     }),
@@ -310,14 +310,14 @@ export function awslBehaviorFingerprint(
   value: AwslBehaviorFingerprintInput,
 ): `sha256:${string}` {
   const captured = record(
-    snapshot(value, "AWSl behavior fingerprint input"),
-    "AWSl behavior fingerprint input",
+    snapshot(value, "awsl behavior fingerprint input"),
+    "awsl behavior fingerprint input",
   );
   exactKeys(
     captured,
     ["config"],
     ["enabledPluginRoots"],
-    "AWSl behavior fingerprint input",
+    "awsl behavior fingerprint input",
   );
   const config = resolvedConfig(captured.config);
   const roots = enabledRoots(captured.enabledPluginRoots);

--- a/tests/compat/agent-definition.test.ts
+++ b/tests/compat/agent-definition.test.ts
@@ -187,7 +187,7 @@ describe("agent definitions", () => {
       } as never),
     ).toThrow();
     expect(WORKFLOW_SUBAGENT_SOURCE).toBe(
-      "---\nname: workflow-subagent\ndescription: Default AWSl workflow subagent\n---\nYou are a workflow subagent. Complete the requested task in the provided\nworking directory, follow the inherited project instructions and provider\npolicy, and return the result needed by the parent workflow.\n",
+      "---\nname: workflow-subagent\ndescription: Default awsl workflow subagent\n---\nYou are a workflow subagent. Complete the requested task in the provided\nworking directory, follow the inherited project instructions and provider\npolicy, and return the result needed by the parent workflow.\n",
     );
   });
 

--- a/tests/config/fingerprints.test.ts
+++ b/tests/config/fingerprints.test.ts
@@ -69,7 +69,7 @@ function configError(error: unknown): boolean {
   );
 }
 
-describe("AWSl behavior fingerprint", () => {
+describe("awsl behavior fingerprint", () => {
   test("is a deterministic lowercase SHA-256 independent of object insertion order", () => {
     const first = config();
     const second = config();
@@ -81,7 +81,7 @@ describe("AWSl behavior fingerprint", () => {
     ) as unknown as ResolvedAwslConfig["providers"];
 
     expect(behavior(first)).toBe(
-      "sha256:58fd212de7243d1476335923df6a8219f8551f2375ff2c7b69d10bead4b156ac",
+      "sha256:18443685b0139e1dc1a20fbbad6c0f9bdf1287cac0b2014d6bf72a34beed3c66",
     );
     expect(behavior(second)).toBe(behavior(first));
   });

--- a/tests/fixtures/real-provider-project/AGENTS.md
+++ b/tests/fixtures/real-provider-project/AGENTS.md
@@ -1,4 +1,4 @@
-# AWSl real-provider fixture
+# awsl real-provider fixture
 
 For this directory, the project instruction marker is
 `AWSL_PROJECT_INSTRUCTION_CODEX_V1`.

--- a/tests/fixtures/real-provider-project/CLAUDE.md
+++ b/tests/fixtures/real-provider-project/CLAUDE.md
@@ -1,4 +1,4 @@
-# AWSl real-provider fixture
+# awsl real-provider fixture
 
 For this directory, the project instruction marker is
 `AWSL_PROJECT_INSTRUCTION_CLAUDE_V1`.

--- a/tests/package/builtin-agent.test.ts
+++ b/tests/package/builtin-agent.test.ts
@@ -82,7 +82,7 @@ test("resolves the emitted builtin from an installed package tarball", async () 
         import { dirname, join } from "node:path";
         import { fileURLToPath, pathToFileURL } from "node:url";
 
-        const packageRoot = dirname(dirname(fileURLToPath(import.meta.resolve("awsl"))));
+        const packageRoot = dirname(dirname(fileURLToPath(import.meta.resolve("@xhinliang/awsl"))));
         const { createRegistry } = await import(pathToFileURL(
           join(packageRoot, "dist", "compat", "agent-registry.js"),
         ));
@@ -91,7 +91,7 @@ test("resolves the emitted builtin from an installed package tarball", async () 
         ));
         let deepImportBlocked = false;
         try {
-          await import("awsl/dist/compat/agent-registry.js");
+          await import("@xhinliang/awsl/dist/compat/agent-registry.js");
         } catch (error) {
           deepImportBlocked = error?.code === "ERR_PACKAGE_PATH_NOT_EXPORTED";
         }
@@ -142,7 +142,7 @@ test("resolves the emitted builtin from an installed package tarball", async () 
       tier: "builtin",
     });
     expect(result.exportedSource).toContain(
-      "name: workflow-subagent\ndescription: Default AWSl workflow subagent",
+      "name: workflow-subagent\ndescription: Default awsl workflow subagent",
     );
     expect(result.instructions).toBe(
       "You are a workflow subagent. Complete the requested task in the provided\n" +

--- a/tests/package/ci-security.test.ts
+++ b/tests/package/ci-security.test.ts
@@ -38,7 +38,9 @@ test("keeps publication OIDC-only and fail-closed on release identity", async ()
   expect(workflow).toMatch(/contents:\s+read/u);
   expect(workflow).toMatch(/id-token:\s+write/u);
   expect(workflow).toContain("npm@11.5.1");
-  expect(workflow).toContain('case "$package_name" in');
+  expect(workflow).toContain(
+    'if [ "$package_name" != "@xhinliang/awsl" ]; then',
+  );
   expect(workflow).toContain('expected_repository="git+https://github.com/');
   expect(workflow).toContain("security/advisories/new");
   expect(workflow).toContain("latest release");
@@ -53,4 +55,18 @@ test("keeps publication OIDC-only and fail-closed on release identity", async ()
   expect(workflow).not.toMatch(
     /NODE_AUTH_TOKEN|NPM_TOKEN|secrets\.[A-Za-z0-9_]+/u,
   );
+
+  const manifest = JSON.parse(
+    await readFile(join(repositoryRoot, "package.json"), "utf8"),
+  ) as {
+    name?: string;
+    publishConfig?: { access?: string; registry?: string };
+  };
+  expect(manifest).toMatchObject({
+    name: "@xhinliang/awsl",
+    publishConfig: {
+      access: "public",
+      registry: "https://registry.npmjs.org/",
+    },
+  });
 });

--- a/tests/package/install-smoke.test.ts
+++ b/tests/package/install-smoke.test.ts
@@ -278,7 +278,7 @@ test("packed CLI installs and runs from a clean directory", async () => {
 
     const installedPackage = JSON.parse(
       await readFile(
-        join(project, "node_modules", "awsl", "package.json"),
+        join(project, "node_modules", "@xhinliang", "awsl", "package.json"),
         "utf8",
       ),
     ) as {
@@ -287,6 +287,7 @@ test("packed CLI installs and runs from a clean directory", async () => {
       bugs?: { url?: string };
       engines?: { node?: string };
       homepage?: string;
+      name?: string;
       repository?: { type?: string; url?: string };
     };
     expect(installedPackage.bin?.awsl).toBe("./dist/cli/main.js");
@@ -295,6 +296,7 @@ test("packed CLI installs and runs from a clean directory", async () => {
       author: "xhinliang <xhinliang@gmail.com>",
       bugs: { url: "https://github.com/XhinLiang/awsl/issues" },
       homepage: "https://github.com/XhinLiang/awsl#readme",
+      name: "@xhinliang/awsl",
       repository: {
         type: "git",
         url: "git+https://github.com/XhinLiang/awsl.git",
@@ -320,7 +322,7 @@ test("packed CLI installs and runs from a clean directory", async () => {
       [
         "--input-type=module",
         "--eval",
-        'import("awsl").then((value) => process.stdout.write(value.COMPAT_PROFILE.id))',
+        'import("@xhinliang/awsl").then((value) => process.stdout.write(value.COMPAT_PROFILE.id))',
       ],
       { cwd: project, timeout: 20_000 },
     );

--- a/tests/package/sbom.test.ts
+++ b/tests/package/sbom.test.ts
@@ -73,11 +73,11 @@ test("generates a deterministic production-only CycloneDX SBOM", async () => {
       version: 1,
       metadata: {
         component: {
-          "bom-ref": "pkg:npm/awsl@0.1.0",
+          "bom-ref": "pkg:npm/%40xhinliang/awsl@0.1.0",
           type: "application",
-          name: "awsl",
+          name: "@xhinliang/awsl",
           version: "0.1.0",
-          purl: "pkg:npm/awsl@0.1.0",
+          purl: "pkg:npm/%40xhinliang/awsl@0.1.0",
           licenses: [{ license: { id: "Apache-2.0" } }],
         },
         properties: [

--- a/tests/runtime/engine.test.ts
+++ b/tests/runtime/engine.test.ts
@@ -1856,7 +1856,7 @@ throw new Error("root worker exploded")
         ["-C", repo, "config", "user.email", "awsl@example.invalid"],
         { encoding: "utf8" },
       );
-      await execFile("git", ["-C", repo, "config", "user.name", "AWSl Test"], {
+      await execFile("git", ["-C", repo, "config", "user.name", "awsl Test"], {
         encoding: "utf8",
       });
       await writeFile(
@@ -2011,7 +2011,7 @@ return await agent(args.prompt, { isolation: "worktree" })
         ["-C", repo, "config", "user.email", "awsl@example.invalid"],
         { encoding: "utf8" },
       );
-      await execFile("git", ["-C", repo, "config", "user.name", "AWSl Test"], {
+      await execFile("git", ["-C", repo, "config", "user.name", "awsl Test"], {
         encoding: "utf8",
       });
       await writeFile(

--- a/tests/runtime/worktree.test.ts
+++ b/tests/runtime/worktree.test.ts
@@ -38,7 +38,7 @@ async function fixture() {
   await mkdir(runDir, { recursive: true });
   await git(repo, "init");
   await git(repo, "config", "user.email", "awsl@example.invalid");
-  await git(repo, "config", "user.name", "AWSl Test");
+  await git(repo, "config", "user.name", "awsl Test");
   await writeFile(join(repo, "README.md"), "base\n");
   await writeFile(join(nested, "tracked.txt"), "tracked\n");
   await git(repo, "add", ".");


### PR DESCRIPTION
## Summary
- standardize the project brand as `awsl` and document Agentic Workflow Steering Layer
- pin the public package identity to `@xhinliang/awsl` while keeping the `awsl` executable
- update package installation tests, SBOM identity, and release guards for the scoped package

## Verification
- `pnpm run check`
- `pnpm exec vitest run --maxWorkers=1 --minWorkers=1` (971 passed, 1 skipped)
- `pnpm run test:package` (7 passed)
- `pnpm run test:conformance` (4 passed)
- `pnpm audit --prod`
- inspected packed manifest and CycloneDX root identity

A bootstrap package and trusted publisher will be configured only after this change passes hosted CI.