### PR TITLE
fix: Support Codex workflows outside Git repositories

### DIFF
--- a/src/providers/codex.ts
+++ b/src/providers/codex.ts
@@ -90,7 +90,7 @@ export function buildCodexArgv(
       );
     argv.push("--sandbox", options.sandboxMode);
   }
-  argv.push("exec", "--json");
+  argv.push("exec", "--json", "--skip-git-repo-check");
   if (schemaPath !== undefined) {
     argv.push("--output-schema", schemaPath);
   }

--- a/src/runtime/engine.ts
+++ b/src/runtime/engine.ts
@@ -1204,10 +1204,13 @@ async function executeAgent(
         }),
       );
       terminal = true;
-      const error = providerError(
-        context.options.provider,
-        "provider output-token usage is indeterminate",
-      );
+      const error =
+        outcome.kind === "error"
+          ? outcome.error
+          : providerError(
+              context.options.provider,
+              "provider output-token usage is indeterminate",
+            );
       await emit(context, "call.failed", {
         callId: identity.callId,
         callSeq,

--- a/tests/cli/run.test.ts
+++ b/tests/cli/run.test.ts
@@ -400,6 +400,7 @@ describe("CLI workflow execution", () => {
       "read-only",
       "exec",
       "--json",
+      "--skip-git-repo-check",
       "-",
     ]);
     expect(invocation.prompt).toContain("CODEX_NATIVE_AUDIT_MARKER");

--- a/tests/providers/codex.test.ts
+++ b/tests/providers/codex.test.ts
@@ -104,6 +104,7 @@ describe("Codex adapter contract", () => {
       'model_reasoning_effort="high"',
       "exec",
       "--json",
+      "--skip-git-repo-check",
       "-",
     ]);
   });
@@ -126,6 +127,7 @@ describe("Codex adapter contract", () => {
       'model_reasoning_effort="high"',
       "exec",
       "--json",
+      "--skip-git-repo-check",
       "-",
     ]);
   });
@@ -152,6 +154,7 @@ describe("Codex adapter contract", () => {
       "workspace-write",
       "exec",
       "--json",
+      "--skip-git-repo-check",
       "-",
     ]);
   });
@@ -186,6 +189,7 @@ describe("Codex adapter contract", () => {
       "--search",
       "exec",
       "--json",
+      "--skip-git-repo-check",
       "-",
     ]);
   });
@@ -436,6 +440,7 @@ describe("Codex adapter contract", () => {
       "gpt-test",
       "exec",
       "--json",
+      "--skip-git-repo-check",
       "--output-schema",
       "/private/tmp/awsl/schema.json",
       "-",
@@ -740,6 +745,7 @@ describe("Codex adapter contract", () => {
         'model_reasoning_effort="high"',
         "exec",
         "--json",
+        "--skip-git-repo-check",
         "-",
       ],
       cwd: "/workspace",
@@ -1555,7 +1561,12 @@ describe("Codex adapter contract", () => {
       }),
     );
 
-    expect(fixture.calls[0]?.argv).toEqual(["exec", "--json", "-"]);
+    expect(fixture.calls[0]?.argv).toEqual([
+      "exec",
+      "--json",
+      "--skip-git-repo-check",
+      "-",
+    ]);
     expect(fixture.calls[0]?.prompt).toBe(
       [
         '<awsl-agent name="reviewer">',

--- a/tests/runtime/engine.test.ts
+++ b/tests/runtime/engine.test.ts
@@ -1117,6 +1117,38 @@ return await agent("two", { agentType: "drift" })
     });
   });
 
+  test("preserves the provider error when failed usage is indeterminate", async () => {
+    const provider = new RecordingProvider(() => ({
+      kind: "error",
+      error: new AwslError("PROVIDER_ERROR", "provider rate limited", {
+        provider: "codex",
+        recoverable: false,
+      }),
+      usage: { inputTokens: 2, complete: false },
+    }));
+    const store = new RecordingStore();
+    const options = await harness("basic-agent.js", provider, store);
+
+    await expect(
+      runWorkflow({
+        ...options,
+        runId: "failed-usage-indeterminate",
+        attemptId: "attempt-0",
+        attemptSeq: 0,
+        args: { prompt: "hello" },
+        lockOwner,
+      }),
+    ).rejects.toMatchObject({
+      code: "PROVIDER_ERROR",
+      message: "provider rate limited",
+    });
+    expect(
+      store.records.filter(
+        (record) => record.kind === "call" && record.state === "indeterminate",
+      ),
+    ).toHaveLength(1);
+  });
+
   test("rejects a proxied provider outcome without invoking any trap", async () => {
     let trapCalls = 0;
     const trap = () => {


### PR DESCRIPTION
## Summary
- allow Codex workflows to run from non-Git umbrella directories by passing `--skip-git-repo-check`
- preserve the original provider failure when output-token usage is indeterminate
- update adapter, CLI, and runtime regression coverage

## Test
- [x] `pnpm test` — 972 passed, 1 skipped
- [x] `pnpm run check`
- [x] full `backend-audit.js` run from `/Users/xhinliang/codes/backend2` — 60/60 calls completed with `usageComplete=true`

## Risk
- Codex no longer applies its own Git-directory admission check; AWSl still resolves and pins the requested canonical cwd
- indeterminate calls remain non-reusable in the journal; only the surfaced error changes
- rollback by reverting commit `c5e493f`