### PR TITLE
release: Prepare v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.1.1 - 2026-07-30
+
+### Fixed
+
+- Allow Codex workflows to run from non-Git working directories.
+- Preserve the original provider failure when output-token usage is
+  indeterminate.
+
 ## 0.1.0 - 2026-07-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xhinliang/awsl",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Agentic Workflow Steering Layer for trusted JavaScript agent workflows",
   "license": "Apache-2.0",
   "author": "xhinliang <xhinliang@gmail.com>",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -4,11 +4,11 @@
   "version": 1,
   "metadata": {
     "component": {
-      "bom-ref": "pkg:npm/%40xhinliang/awsl@0.1.0",
+      "bom-ref": "pkg:npm/%40xhinliang/awsl@0.1.1",
       "type": "application",
       "name": "@xhinliang/awsl",
-      "version": "0.1.0",
-      "purl": "pkg:npm/%40xhinliang/awsl@0.1.0",
+      "version": "0.1.1",
+      "purl": "pkg:npm/%40xhinliang/awsl@0.1.1",
       "licenses": [
         {
           "license": {
@@ -171,7 +171,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40xhinliang/awsl@0.1.0",
+      "ref": "pkg:npm/%40xhinliang/awsl@0.1.1",
       "dependsOn": [
         "pkg:npm/acorn-walk@8.3.5",
         "pkg:npm/acorn@8.17.0",

--- a/tests/package/sbom.test.ts
+++ b/tests/package/sbom.test.ts
@@ -31,6 +31,10 @@ test("generates a deterministic production-only CycloneDX SBOM", async () => {
   const root = await mkdtemp(join(tmpdir(), "awsl-sbom-"));
   const firstPath = join(root, "first.cdx.json");
   const secondPath = join(root, "second.cdx.json");
+  const packageManifest = JSON.parse(
+    await readFile(join(repositoryRoot, "package.json"), "utf8"),
+  ) as { readonly version: string };
+  const rootPurl = `pkg:npm/%40xhinliang/awsl@${packageManifest.version}`;
 
   try {
     for (const output of [firstPath, secondPath])
@@ -73,11 +77,11 @@ test("generates a deterministic production-only CycloneDX SBOM", async () => {
       version: 1,
       metadata: {
         component: {
-          "bom-ref": "pkg:npm/%40xhinliang/awsl@0.1.0",
+          "bom-ref": rootPurl,
           type: "application",
           name: "@xhinliang/awsl",
-          version: "0.1.0",
-          purl: "pkg:npm/%40xhinliang/awsl@0.1.0",
+          version: packageManifest.version,
+          purl: rootPurl,
           licenses: [{ license: { id: "Apache-2.0" } }],
         },
         properties: [


### PR DESCRIPTION
## Summary
- bump `@xhinliang/awsl` to `0.1.1`
- add the `0.1.1` changelog entry and regenerate the release SBOM
- make the SBOM contract test derive the root version from `package.json`

## Test
- [x] `pnpm run check`
- [x] `pnpm test` — 972 passed, 1 skipped
- [x] `pnpm run test:package` — 7 passed
- [x] `pnpm run test:conformance` — 4 passed
- [x] built and inspected `xhinliang-awsl-0.1.1.tgz`

## Risk
- metadata-only release changes plus a test-only removal of a hard-coded version
- publishing remains gated by the GitHub Release OIDC workflow and npm provenance
- rollback by deprecating `0.1.1`; npm versions are immutable