### PR TITLE
feat: Decouple workflow compatibility and improve help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,23 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Stable `awsl-workflow@1` ABI reporting and agent-oriented CLI help with
+  examples, input rules, output semantics, and nested command discovery.
 - Runnable research, code-review, worktree, and durable-resume example
   workflows with offline contract tests.
 - Public positioning, migration, contribution, and community guidance.
 
 ### Changed
 
+- Accept strictly branded provider semantic versions without a patch-version
+  allowlist, report unverified versions, and base doctor readiness on the
+  selected provider while preserving exact-version resume pins.
 - Improve npm discovery metadata and the repository onboarding experience.
+
+### Fixed
+
+- Make `awsl help`, nested help paths, and an empty invocation exit successfully,
+  while rejecting unknown nested commands instead of showing misleading help.
 
 ## 0.1.1 - 2026-07-30
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ pnpm run build
 ## Pull requests
 
 Keep changes focused and explain their effect on the public CLI, JavaScript
-workflow API, events, compatibility profile, and durable state. Add tests for
+workflow API, events, Workflow ABI, provider protocol, and durable state. Add tests for
 behavior changes and state any real-provider evidence that is still missing.
 Behavior changes should start with a failing regression test.
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ npm install --global @xhinliang/awsl
 awsl doctor
 ```
 
-`doctor` reports every provider independently. A `degraded` result is expected
-when an unused provider is not installed; the provider you select must pass its
-checks.
+`doctor` reports every provider independently and bases overall readiness on
+the selected provider. An unavailable unused provider does not degrade the
+selected path. Versions with committed protocol evidence are `verified`; other
+strictly branded semantic versions are `unverified` and may still run.
 
 Create `review.js`:
 
@@ -113,14 +114,14 @@ domain layer.
 
 - Node.js 22 or newer
 - Git for `isolation: "worktree"`
-- At least one supported provider executable:
-  - Codex CLI `0.145.0` or `0.146.0`
-  - Claude Code `2.1.218`
+- At least one Codex CLI or Claude Code executable with a standard semantic
+  version banner
 
-Provider versions are exact compatibility inputs. `awsl doctor` and run
-preparation reject other versions. This release targets the observable workflow
-behavior of `claude-code@2.1.218`; it does not claim byte-for-byte, universal,
-or future Claude Code equivalence.
+awsl owns and versions the JavaScript Workflow ABI independently from provider
+executables. This release normalizes structurally compatible workflow files to
+`awsl-workflow@1`. Codex CLI `0.145.0` and `0.146.0`, and Claude Code `2.1.218`,
+have committed protocol evidence; newer versions are accepted as `unverified`
+rather than rejected by a patch-version allowlist.
 
 See the
 [compatibility report](docs/compatibility/claude-code-2.1.218.md) for the
@@ -147,6 +148,7 @@ awsl runs pause <run-id>
 awsl doctor
 awsl config show
 awsl workflow inspect <workflow>
+awsl help <command>
 ```
 
 `run` accepts:
@@ -165,7 +167,7 @@ Input JSON is strict, rejects duplicate keys, and is limited to 512 KiB.
 
 `resume` accepts replacement `--args`, `--args-file`, `--budget`, and
 `--format`. The workflow source identity, provider, executable, provider
-profile, working directory, compatibility profile, and model policy remain
+profile, working directory, Workflow ABI, and model policy remain
 pinned. Drift is rejected before another provider call starts.
 
 Output contracts:
@@ -177,12 +179,16 @@ Output contracts:
 - `SIGINT` exits 130 and `SIGTERM` exits 143 after a durable terminal record.
 
 `doctor` probes Node, Git, Codex, and Claude versions without invoking a model.
+Its overall status follows the configured provider, while every provider keeps
+an independent availability and evidence status.
 
 ## Workflow contract
 
 The first statement must be a pure literal `export const meta = ...`.
 `meta.name` and `meta.description` are required non-empty strings. Workflow
 source is limited to 512 KiB and may use top-level `await` and `return`.
+`awsl workflow inspect <file>` reports the normalized Workflow ABI. The ABI is
+versioned by awsl rather than by the installed Claude or Codex executable.
 
 The workflow global API is:
 
@@ -212,7 +218,7 @@ Supported `agent` options are:
 ```
 
 Non-cancellation failures inside `parallel` and `pipeline` become `null` and
-emit a log, matching the reviewed compatibility profile. A `null` pipeline
+emit a log, matching the stable Workflow ABI. A `null` pipeline
 value skips the remaining stages for that item. Child workflows inherit the
 root provider and shared limits; a child cannot recursively start another child.
 

--- a/docs/compatibility/claude-code-2.1.218.md
+++ b/docs/compatibility/claude-code-2.1.218.md
@@ -2,21 +2,25 @@
 
 ## TL;DR
 
-- awsl records observable workflow behavior for the pinned Claude Code profile; it does not claim byte-for-byte or future-version compatibility.
+- awsl owns the stable `awsl-workflow@1` Workflow ABI; Claude Code 2.1.218 is
+  the original behavioral oracle, not a required provider patch version.
 - An independently authored 19-call fixture exercises public orchestration, phase accounting, event ordering, durable state, and side-effect isolation.
 - Real-provider evidence remains limited to the exact Codex scenarios and versions stated below; authenticated Claude evidence is still absent.
 
-**Profile:** `claude-code@2.1.218`
+**Workflow ABI:** `awsl-workflow@1`
 
-**Report date:** 2026-08-01
+**Original oracle:** `claude-code@2.1.218`
+
+**Report date:** 2026-08-06
 
 **Release state:** `@xhinliang/awsl@0.1.1` is published on npm and GitHub.
 
 **Overall status:** `partial`
 
-awsl implements the observable JavaScript workflow behaviors listed below. This
-report does not claim byte-for-byte equivalence, compatibility with future
-Claude Code releases, or equivalence for rows marked `partial` or `gap`.
+awsl implements the observable JavaScript workflow behaviors listed below and
+normalizes structurally compatible files to its own ABI. This report does not
+claim byte-for-byte equivalence, provider-protocol compatibility without the
+stated evidence, or equivalence for rows marked `partial` or `gap`.
 
 Statuses:
 
@@ -51,7 +55,7 @@ Evidence types:
 | Text and schema `agent()` results | `verified` | `static`, `fixture-provider` | `tests/runtime/engine.test.ts` — `validates structured results again before completing the call`; `tests/providers/schema.test.ts` — `rejects workflow-controlled regular expressions`, `rejects workflow-controlled schema references`; `tests/cli/run.test.ts` — `runs a real Codex JSONL protocol fixture and includes result in completion` | Workflow-controlled regex keywords and schema references are rejected to avoid coordinator-side ReDoS. |
 | Project and namespaced-plugin child workflows | `verified` | `static` | `tests/runtime/engine.test.ts` — `runs project and namespaced plugin workflows in the parent run`, `shares budget, counters, run identity, and a forced child phase` | Parent run identity, provider pin, shared budget, forced child phase, and registry provenance are checked. |
 | Nested-workflow depth and shared provider/semaphore/budget/call cap | `verified` | `static` | `tests/runtime/engine.test.ts` — `rejects a grandchild before launching an agent`, `enforces the shared 1000-call cap before replaying a cached child call`; `tests/runtime/scheduler.test.ts` — `never exceeds its limit and admits work in FIFO order` | Grandchildren fail before provider launch. |
-| Fixed provider identity and no provider fallback | `verified` | `static`, `fixture-provider` | `tests/config/provider-identity.test.ts` — `normalizes only the exact trimmed banners and rejects controls, BOM, and foreign versions`; `tests/providers/process.test.ts` — `uses exact argv and cwd, inherits env, and keeps hostile text off a shell`; `tests/runtime/engine.test.ts` — `rejects a resume pin mismatch before locking, replay, or provider use` | Executable, exact supported version, cwd, sources, model policy, and fingerprints are pinned. |
+| Fixed provider identity and no provider fallback | `verified` | `static`, `fixture-provider` | `tests/config/provider-identity.test.ts` — `normalizes branded semantic versions without coupling runtime support to a patch release`; `tests/providers/process.test.ts` — `uses exact argv and cwd, inherits env, and keeps hostile text off a shell`; `tests/runtime/engine.test.ts` — `rejects a resume pin mismatch before locking, replay, or provider use` | New runs accept branded semantic versions. The selected executable and exact observed version remain pinned for resume. |
 | Configured private native-model pinning | `verified` | `static` | `tests/config/provider-pin.test.ts` — `captures configured native models for a discovered default`, `upgrades a legacy V1 base-native default but rejects a downgrade`; `tests/runtime/engine.test.ts` — `rejects a legacy V1 pin for a fresh run before locking or provider use`, `durably discovers and resumes a configured native default`, `upgrades a V1 pin to V2 before a live resumed call` | Provider Pin V2 persists the sorted configured-native set. V1 is legacy-read-only and upgrades only after shared fingerprints match; V2-to-V1 is rejected. |
 | Output-token budget, bounded active-call overshoot, and 1,000-call cap | `verified` | `static` | `tests/runtime/budget.test.ts` — `allows an active completion to overshoot and gates only later work`; `tests/runtime/engine.test.ts` — `enforces the shared 1000-call cap before replaying a cached child call` | Budget is charged from output tokens and shared across nested work. |
 | Durable state, bounded streams, append-only journal, and longest-prefix replay | `verified` | `static` | `tests/runtime/engine.test.ts` — `writes a validator-clean file journal and resumes its longest prefix`; `tests/store/run-store.test.ts` — `strictly and boundedly reads run, result, and lock snapshots`; `tests/store/run-store-fake-ops.test.ts` — `never truncates a valid final stream record after LF repair I/O fails` | Matching read/write limits and bounded tail repair are asserted. |
@@ -76,12 +80,14 @@ git diff --check
 
 ## Provider and oracle evidence
 
-awsl accepts exactly Codex CLI `0.145.0` or `0.146.0` and Claude Code
-`2.1.218`. `awsl doctor` and run preparation fail closed for other versions;
-those exact versions are part of this profile rather than a promise about later
-provider releases. The real-provider Codex evidence below remains specific to
-`0.145.0`; `0.146.0` support is covered by version-locked static and fixture
-tests, not a claimed real-provider acceptance run.
+awsl accepts strictly branded semantic versions from Codex CLI and Claude Code
+without a patch-version allowlist. `awsl doctor` marks versions with the
+evidence below as `verified` and other versions as `unverified`. This is not a
+claim that an unverified provider protocol is unchanged: adapter validation and
+runtime parsing still fail closed when required flags or events are absent. The
+real-provider Codex evidence below remains specific to `0.145.0`; `0.146.0`
+support is covered by static and fixture tests, not a claimed real-provider
+acceptance run.
 
 | Behavior | Status | Evidence | Evidence pointer | Boundary |
 |---|---|---|---|---|

--- a/docs/why-awsl.md
+++ b/docs/why-awsl.md
@@ -109,9 +109,11 @@ events. It is also useful when the same workflow should select Codex or Claude
 at run start without duplicating orchestration code.
 
 Choose another layer when you need untrusted-code isolation, a distributed
-queue, cross-provider fallback during a run, native Windows execution, or
-compatibility with arbitrary provider versions. Application-specific scripts
-remain simpler for short, disposable, single-call tasks.
+queue, cross-provider fallback during a run, or native Windows execution.
+Provider protocol changes still require adapter coverage even though awsl does
+not reject new releases solely because their patch version changed.
+Application-specific scripts remain simpler for short, disposable, single-call
+tasks.
 
 ## Evidence and limits
 
@@ -124,5 +126,5 @@ proof of compatibility:
 - [SECURITY.md](../SECURITY.md) defines the supported versions and reporting channel.
 
 Version `0.1.1` is published. Authenticated Claude workflow acceptance remains
-an evidence gap, and the supported provider versions remain intentionally
-exact rather than forward-compatible claims.
+an evidence gap. The Workflow ABI is owned by awsl; provider versions without
+committed protocol evidence are identified as unverified rather than rejected.

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -94,6 +94,12 @@ const knownCommands = new Set([
   "workflow",
   "help",
 ]);
+const nestedCommands: Readonly<Record<string, ReadonlySet<string>>> =
+  Object.freeze({
+    runs: new Set(["list", "show", "pause"]),
+    config: new Set(["show"]),
+    workflow: new Set(["inspect"]),
+  });
 const diagnosticText: Record<AwslErrorCode, string> = {
   USAGE_ERROR: "invalid command line",
   CONFIG_ERROR: "configuration validation failed",
@@ -256,6 +262,34 @@ function rewriteLeadingWorkflow(argv: readonly string[]): string[] {
   const first = argv[0] as string;
   if (first.startsWith("-") || knownCommands.has(first)) return [...argv];
   return ["run", ...argv];
+}
+
+function rewriteHelpPath(argv: readonly string[]): string[] {
+  if (argv[0] !== "help" || argv.length === 1) return [...argv];
+  const command = argv[1] as string;
+  if (!knownCommands.has(command) || command === "help") usage();
+  const children = nestedCommands[command];
+  if (children === undefined) {
+    if (argv.length !== 2) usage();
+    return [command, "--help"];
+  }
+  if (argv.length === 2) return [command, "--help"];
+  const child = argv[2] as string;
+  if (argv.length !== 3 || !children.has(child)) usage();
+  return [command, child, "--help"];
+}
+
+function rejectUnknownNestedCommand(argv: readonly string[]): void {
+  const children = nestedCommands[argv[0] as string];
+  const child = argv[1];
+  if (
+    children !== undefined &&
+    child !== undefined &&
+    !child.startsWith("-") &&
+    child !== "help" &&
+    !children.has(child)
+  )
+    usage();
 }
 
 function rejectDuplicateLongOptions(argv: readonly string[]): void {
@@ -950,7 +984,7 @@ function buildProgram(
   const program = new Command();
   program
     .name("awsl")
-    .description("Run Claude Code-compatible JavaScript workflows")
+    .description("Run durable JavaScript workflows with Codex or Claude")
     .version(packageVersion)
     .exitOverride()
     .configureOutput({
@@ -959,9 +993,25 @@ function buildProgram(
       },
       writeErr: () => {},
       outputError: () => {},
-    });
+    })
+    .addHelpText(
+      "after",
+      `
+Start here:
+  awsl doctor
+  awsl workflow inspect <workflow>
+  awsl run <workflow> --provider codex --args '{"key":"value"}'
 
-  addFormat(
+Workflow contract:
+  Start with a pure literal "export const meta = { name, description }".
+  Available globals include args, agent, parallel, pipeline, phase, log,
+  workflow, budget, setTimeout, and clearTimeout.
+
+Use "awsl help <command>" or "awsl help <group> <command>" for details.
+Workflow files are trusted code. A run uses one provider and never falls back.`,
+    );
+
+  const run = addFormat(
     program
       .command("run")
       .description("run a workflow")
@@ -971,11 +1021,26 @@ function buildProgram(
       .option("--args-file <path>", "workflow arguments file or -")
       .option("--cwd <path>", "session working directory")
       .option("--budget <tokens>", "output token budget"),
-  ).action(async (workflow: string, options: RunCommandOptions) => {
+  ).addHelpText(
+    "after",
+    `
+Arguments:
+  --args, --args-file, and non-empty piped stdin are mutually exclusive.
+  JSON is strict, rejects duplicate keys, and is limited to 512 KiB.
+
+Output:
+  auto uses pretty on a TTY and jsonl otherwise. json emits one terminal envelope.
+  A run uses one provider for the complete workflow tree and never falls back.
+
+Examples:
+  awsl run review.js --provider codex --args '{"request":"review auth"}'
+  awsl review.js --args-file input.json --format json`,
+  );
+  run.action(async (workflow: string, options: RunCommandOptions) => {
     setExitCode(await runCommand(workflow, options, context));
   });
 
-  addFormat(
+  const resume = addFormat(
     program
       .command("resume")
       .description("resume a durable run")
@@ -983,52 +1048,124 @@ function buildProgram(
       .option("--args <json>", "replacement workflow arguments")
       .option("--args-file <path>", "replacement arguments file or -")
       .option("--budget <tokens>", "replacement output token budget"),
-  ).action(async (runId: string, options: ResumeCommandOptions) => {
+  ).addHelpText(
+    "after",
+    `
+Resume reuses the longest valid journal prefix. Provider, executable version,
+working directory, workflow sources, and model policy remain pinned.
+
+Example:
+  awsl resume <run-id> --args-file input.json --format json`,
+  );
+  resume.action(async (runId: string, options: ResumeCommandOptions) => {
     setExitCode(await resumeCommand(runId, options, context));
   });
 
-  const runs = program.command("runs").description("inspect durable runs");
-  addFormat(runs.command("list").description("list runs")).action(
-    async (options: FormatCommandOptions) => {
-      setExitCode(await runsListCommand(options, context));
-    },
+  const runs = program
+    .command("runs")
+    .description("inspect durable runs")
+    .addHelpText(
+      "after",
+      `
+Run IDs are scoped to the current project and configured state directory.
+Use "awsl help runs <command>" for command-specific help.`,
+    );
+  const runsList = addFormat(
+    runs.command("list").description("list runs"),
+  ).addHelpText(
+    "after",
+    `
+Lists durable runs for the current project, including status, active ownership,
+attempt number, and whether interrupted work may execute at least once.`,
   );
-  addFormat(
+  runsList.action(async (options: FormatCommandOptions) => {
+    setExitCode(await runsListCommand(options, context));
+  });
+  const runsShow = addFormat(
     runs.command("show").description("show one run").argument("<run-id>"),
-  ).action(async (runId: string, options: FormatCommandOptions) => {
+  ).addHelpText(
+    "after",
+    `
+Shows the durable run snapshot, terminal result when present, active ownership,
+and at-least-once warning state for the current project.`,
+  );
+  runsShow.action(async (runId: string, options: FormatCommandOptions) => {
     setExitCode(await runsShowCommand(runId, options, context));
   });
-  addFormat(
+  const runsPause = addFormat(
     runs
       .command("pause")
       .description("cooperatively pause one active run")
       .argument("<run-id>"),
-  ).action(async (runId: string, options: FormatCommandOptions) => {
+  ).addHelpText(
+    "after",
+    `
+Verifies the recorded process identity, requests a cooperative pause, and waits
+for durable confirmation. Continue later with "awsl resume <run-id>".`,
+  );
+  runsPause.action(async (runId: string, options: FormatCommandOptions) => {
     setExitCode(await runsPauseCommand(runId, options, context));
   });
 
-  addFormat(
+  const doctor = addFormat(
     program.command("doctor").description("check local capabilities"),
-  ).action(async (options: FormatCommandOptions) => {
+  ).addHelpText(
+    "after",
+    `
+Doctor checks Node, Git, Codex, and Claude without invoking a model. Overall
+status follows the selected provider; an unavailable unused provider does not
+block a run. New provider versions are reported as unverified, not rejected.`,
+  );
+  doctor.action(async (options: FormatCommandOptions) => {
     setExitCode(await doctorCommand(options, context));
   });
 
-  const config = program.command("config").description("inspect configuration");
-  addFormat(
+  const config = program
+    .command("config")
+    .description("inspect configuration")
+    .addHelpText(
+      "after",
+      `
+Configuration precedence is CLI, AWSL_ environment, project config, user
+config, then defaults. "config show" includes field provenance.`,
+    );
+  const configShow = addFormat(
     config.command("show").description("show merged configuration"),
-  ).action(async (options: FormatCommandOptions) => {
+  ).addHelpText(
+    "after",
+    `
+Reports resolved configuration, per-field provenance, and hashed config source
+identities with defensive secret redaction.`,
+  );
+  configShow.action(async (options: FormatCommandOptions) => {
     setExitCode(await configShowCommand(options, context));
   });
 
-  const workflow = program.command("workflow").description("inspect workflows");
-  addFormat(
+  const workflow = program
+    .command("workflow")
+    .description("inspect workflows")
+    .addHelpText(
+      "after",
+      `
+Inspection validates trusted JavaScript without probing a provider or invoking
+a model. It reports the normalized awsl Workflow ABI and metadata.`,
+    );
+  const workflowInspect = addFormat(
     workflow
       .command("inspect")
       .description("validate and inspect a workflow")
       .argument("<file>"),
-  ).action(async (file: string, options: FormatCommandOptions) => {
-    setExitCode(await workflowInspectCommand(file, options, context));
-  });
+  ).addHelpText(
+    "after",
+    `
+Parses and validates the file locally, then reports its canonical path, source
+hash, metadata, and normalized Workflow ABI. No provider or model is invoked.`,
+  );
+  workflowInspect.action(
+    async (file: string, options: FormatCommandOptions) => {
+      setExitCode(await workflowInspectCommand(file, options, context));
+    },
+  );
   return program;
 }
 
@@ -1040,7 +1177,9 @@ export async function executeCli(
   let exitCode = 0;
   const helpWrites: Promise<void>[] = [];
   try {
-    const rewritten = rewriteLeadingWorkflow(argv);
+    const requested = argv.length === 0 ? ["help"] : argv;
+    const rewritten = rewriteLeadingWorkflow(rewriteHelpPath(requested));
+    rejectUnknownNestedCommand(rewritten);
     rejectDuplicateLongOptions(rewritten);
     if (
       rewritten[0] === "resume" &&
@@ -1062,7 +1201,8 @@ export async function executeCli(
     await Promise.allSettled(helpWrites);
     if (
       error instanceof CommanderError &&
-      (error.code === "commander.helpDisplayed" ||
+      (error.code === "commander.help" ||
+        error.code === "commander.helpDisplayed" ||
         error.code === "commander.version")
     )
       return 0;

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -12,7 +12,10 @@ import {
 } from "../compat/agent-registry.js";
 import { loadConfig } from "../config/load.js";
 import { canonicalCwd, resolveProjectRoot } from "../config/paths.js";
-import { resolveProviderIdentity } from "../config/provider-identity.js";
+import {
+  providerVersionSupport,
+  resolveProviderIdentity,
+} from "../config/provider-identity.js";
 import {
   type ProviderPinV2,
   type RunSourceIdentityV1,
@@ -836,6 +839,7 @@ async function workflowInspectCommand(
       reference: root.reference,
       realpath: root.realpath,
       sha256: root.sha256,
+      workflowAbi: root.workflowAbi,
       meta: root.meta,
     },
     rawOptions.format,
@@ -875,7 +879,11 @@ async function doctorCommand(
         cwd,
         env: context.env,
       });
-      return { available: true, version: identity.version };
+      return {
+        available: true,
+        version: identity.version,
+        support: providerVersionSupport(id, identity.version),
+      };
     } catch (error) {
       return {
         available: false,
@@ -909,12 +917,16 @@ async function doctorCommand(
     version: process.versions.node,
   };
   const checks = { node, git, codex, claude };
+  const selectedProvider = loaded.value.provider;
+  const selected = checks[selectedProvider];
   await writeValue(
     context,
     {
-      status: Object.values(checks).every((check) => check.available)
-        ? "ok"
-        : "degraded",
+      status:
+        node.available && git.available && selected.available
+          ? "ok"
+          : "degraded",
+      selectedProvider,
       checks,
     },
     rawOptions.format,

--- a/src/compat/compile.ts
+++ b/src/compat/compile.ts
@@ -5,7 +5,7 @@ import { type Node, type Program, parse } from "acorn";
 import { AwslError } from "../core/errors.js";
 import { DeterminismError, assertDeterministic } from "./determinism.js";
 import { PureLiteralError, evaluateLiteral } from "./literal.js";
-import { COMPATIBILITY_PROFILE } from "./profile.js";
+import { WORKFLOW_ABI } from "./profile.js";
 
 type AstNode = Node & Record<string, unknown>;
 
@@ -24,6 +24,7 @@ export interface CompiledWorkflowMeta {
 }
 
 export interface CompiledWorkflow {
+  workflowAbi: typeof WORKFLOW_ABI.id;
   meta: CompiledWorkflowMeta;
   code: string;
   filename: string;
@@ -132,9 +133,7 @@ export function compileWorkflow(
   source: string,
   filename: string,
 ): CompiledWorkflow {
-  if (
-    Buffer.byteLength(source, "utf8") > COMPATIBILITY_PROFILE.maxSourceBytes
-  ) {
+  if (Buffer.byteLength(source, "utf8") > WORKFLOW_ABI.maxSourceBytes) {
     throw compatibilityError("workflow source exceeds the 512 KiB limit");
   }
 
@@ -161,6 +160,7 @@ export function compileWorkflow(
     const meta = metadataFrom(evaluateLiteral(declarator.init as AstNode));
     const body = blankMetadata(source, first.start, first.end);
     return {
+      workflowAbi: WORKFLOW_ABI.id,
       meta,
       code: `(async function __awslWorkflow__() {"use strict";${body}\n}).call(undefined)`,
       filename,

--- a/src/compat/profile.ts
+++ b/src/compat/profile.ts
@@ -1,5 +1,12 @@
-export const COMPATIBILITY_PROFILE = {
-  id: "claude-code@2.1.218",
+/**
+ * The stable contract implemented by the awsl workflow compiler and runtime.
+ *
+ * Claude Code 2.1.218 was the original behavioral oracle for this contract,
+ * but the contract is owned and versioned by awsl. It is deliberately not a
+ * provider executable version.
+ */
+export const WORKFLOW_ABI = {
+  id: "awsl-workflow@1",
   agentCap: 1000,
   structuredOutputAttempts: 5,
   maxSourceBytes: 512 * 1024,
@@ -11,4 +18,16 @@ export const COMPATIBILITY_PROFILE = {
     stderrTailBytes: 64 * 1024,
     killGraceMs: 1_000,
   },
+} as const;
+
+/** Internal compatibility alias retained while callers migrate to WORKFLOW_ABI. */
+export const COMPATIBILITY_PROFILE = WORKFLOW_ABI;
+
+/**
+ * Provider Pin V1/V2 and behavior-fingerprint V1 encoded the original oracle
+ * name. Keep this immutable so runs created by awsl 0.1.x remain resumable.
+ */
+export const LEGACY_COMPATIBILITY_PROFILE = {
+  ...WORKFLOW_ABI,
+  id: "claude-code@2.1.218",
 } as const;

--- a/src/config/fingerprints.ts
+++ b/src/config/fingerprints.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { isAbsolute } from "node:path";
 
 import { WORKFLOW_SUBAGENT_SOURCE } from "../compat/builtins/workflow-subagent.js";
-import { COMPATIBILITY_PROFILE } from "../compat/profile.js";
+import { LEGACY_COMPATIBILITY_PROFILE } from "../compat/profile.js";
 import {
   canonicalJson,
   isUnicodeScalarString,
@@ -329,7 +329,9 @@ export function awslBehaviorFingerprint(
     config,
     enabledPluginRoots: roots,
     registryRules: REGISTRY_FINGERPRINT_RULES,
-    compatibilityProfile: COMPATIBILITY_PROFILE,
+    // Fingerprint V1 shipped with this field and value. Preserve its exact
+    // encoding so a workflow-ABI rename does not strand durable 0.1.x runs.
+    compatibilityProfile: LEGACY_COMPATIBILITY_PROFILE,
     builtinAssets: {
       "workflow-subagent": builtinHash,
     },

--- a/src/config/provider-identity.ts
+++ b/src/config/provider-identity.ts
@@ -15,6 +15,22 @@ export {
 } from "./provider-version-process.js";
 
 export const PROVIDER_VERSION_STREAM_LIMIT_BYTES = 64 * 1024;
+const SEMVER_CORE =
+  "(?:0|[1-9][0-9]{0,5})\\.(?:0|[1-9][0-9]{0,5})\\.(?:0|[1-9][0-9]{0,5})";
+const NORMALIZED_PROVIDER_VERSION = new RegExp(`^${SEMVER_CORE}$`, "u");
+const CODEX_VERSION_BANNER = new RegExp(`^codex-cli (${SEMVER_CORE})$`, "u");
+const CLAUDE_VERSION_BANNER = new RegExp(
+  `^(${SEMVER_CORE}) \\(Claude Code\\)$`,
+  "u",
+);
+const VERIFIED_PROVIDER_VERSIONS: Readonly<
+  Record<ProviderId, ReadonlySet<string>>
+> = Object.freeze({
+  codex: new Set(["0.145.0", "0.146.0"]),
+  claude: new Set(["2.1.218"]),
+});
+
+export type ProviderVersionSupport = "verified" | "unverified";
 
 export interface ProviderVersionProbeInput {
   readonly executableRealpath: string;
@@ -297,21 +313,34 @@ export function validateNormalizedProviderVersion(
   value: unknown,
 ): string {
   if (
-    (provider === "codex" && (value === "0.145.0" || value === "0.146.0")) ||
-    (provider === "claude" && value === "2.1.218")
+    (provider === "codex" || provider === "claude") &&
+    typeof value === "string" &&
+    NORMALIZED_PROVIDER_VERSION.test(value)
   )
     return value;
   return compatibilityError(provider, "provider version is incompatible");
+}
+
+export function providerVersionSupport(
+  provider: ProviderId,
+  version: string,
+): ProviderVersionSupport {
+  const normalized = validateNormalizedProviderVersion(provider, version);
+  return VERIFIED_PROVIDER_VERSIONS[provider].has(normalized)
+    ? "verified"
+    : "unverified";
 }
 
 export function normalizeProviderVersionBanner(
   provider: ProviderId,
   value: string,
 ): string {
-  if (provider === "codex" && value === "codex-cli 0.145.0") return "0.145.0";
-  if (provider === "codex" && value === "codex-cli 0.146.0") return "0.146.0";
-  if (provider === "claude" && value === "2.1.218 (Claude Code)")
-    return "2.1.218";
+  const match =
+    provider === "codex"
+      ? CODEX_VERSION_BANNER.exec(value)
+      : CLAUDE_VERSION_BANNER.exec(value);
+  if (match?.[1] !== undefined)
+    return validateNormalizedProviderVersion(provider, match[1]);
   return compatibilityError(provider, "provider version is incompatible");
 }
 

--- a/src/config/provider-pin.ts
+++ b/src/config/provider-pin.ts
@@ -1,7 +1,10 @@
 import { isAbsolute } from "node:path";
 import { isProxy } from "node:util/types";
 
-import { COMPATIBILITY_PROFILE } from "../compat/profile.js";
+import {
+  LEGACY_COMPATIBILITY_PROFILE,
+  WORKFLOW_ABI,
+} from "../compat/profile.js";
 import { AwslError } from "../core/errors.js";
 import type { ProviderId, ProviderIdentity } from "../core/types.js";
 import {
@@ -44,7 +47,9 @@ export type RunSourceIdentityV1 =
 
 interface ProviderPinCommon {
   readonly provider: ProviderId;
-  readonly compatibilityProfile: typeof COMPATIBILITY_PROFILE.id;
+  readonly compatibilityProfile:
+    | typeof WORKFLOW_ABI.id
+    | typeof LEGACY_COMPATIBILITY_PROFILE.id;
   readonly executableRealpath: string;
   readonly executableVersion: string;
   readonly explicitDefaultModel: string | null;
@@ -484,6 +489,14 @@ function providerVersion(provider: ProviderId, value: unknown): string {
   }
 }
 
+function compatibilityProfile(
+  value: unknown,
+): ProviderPinCommon["compatibilityProfile"] {
+  if (value !== WORKFLOW_ABI.id && value !== LEGACY_COMPATIBILITY_PROFILE.id)
+    configError("provider pin compatibilityProfile is invalid");
+  return value;
+}
+
 function providerProfile(provider: ProviderId, value: unknown): string | null {
   if (value === null) return null;
   if (provider !== "codex")
@@ -572,8 +585,9 @@ function parsePinCommon(
   const provider = input.provider;
   if (provider !== "codex" && provider !== "claude")
     configError("provider pin provider is invalid");
-  if (input.compatibilityProfile !== COMPATIBILITY_PROFILE.id)
-    configError("provider pin compatibilityProfile is invalid");
+  const parsedCompatibilityProfile = compatibilityProfile(
+    input.compatibilityProfile,
+  );
 
   const explicitDefaultModel = nullableText(
     input.explicitDefaultModel,
@@ -597,7 +611,7 @@ function parsePinCommon(
 
   return {
     provider,
-    compatibilityProfile: COMPATIBILITY_PROFILE.id,
+    compatibilityProfile: parsedCompatibilityProfile,
     executableRealpath: absoluteLexicalPath(
       input.executableRealpath,
       "provider pin executableRealpath",
@@ -760,7 +774,7 @@ export async function createProviderPin(
   return parseProviderPinV2({
     version: 2,
     provider: config.provider,
-    compatibilityProfile: COMPATIBILITY_PROFILE.id,
+    compatibilityProfile: WORKFLOW_ABI.id,
     executableRealpath: identity.executableRealpath,
     executableVersion: identity.version,
     explicitDefaultModel,
@@ -915,7 +929,9 @@ export function verifyAndHydrateResumePin(
     ["provider", storedPin.provider === currentPin.provider],
     [
       "compatibilityProfile",
-      storedPin.compatibilityProfile === currentPin.compatibilityProfile,
+      storedPin.compatibilityProfile === currentPin.compatibilityProfile ||
+        (storedPin.compatibilityProfile === LEGACY_COMPATIBILITY_PROFILE.id &&
+          currentPin.compatibilityProfile === WORKFLOW_ABI.id),
     ],
     [
       "executableRealpath",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-export { COMPATIBILITY_PROFILE as COMPAT_PROFILE } from "./compat/profile.js";
+export {
+  LEGACY_COMPATIBILITY_PROFILE as COMPAT_PROFILE,
+  WORKFLOW_ABI,
+} from "./compat/profile.js";
 
 export { AwslError } from "./core/errors.js";
 export { WorkerHost } from "./worker/host.js";

--- a/src/providers/claude.ts
+++ b/src/providers/claude.ts
@@ -237,7 +237,7 @@ function snapshotAgentPolicy(
       permissionMode.includes("\0"))
   ) {
     throw compatibilityError(
-      "Claude Code 2.1.218 does not support the requested permission mode",
+      "the Claude provider protocol does not support the requested permission mode",
     );
   }
   if (permissionModePresent) policy.permissionMode = permissionMode as string;
@@ -250,7 +250,7 @@ function validateAgentPolicy(
   if (request.model !== undefined) assertCliValue(request.model, "model");
   if (request.effort !== undefined && !CLAUDE_EFFORT_SET.has(request.effort)) {
     throw compatibilityError(
-      `Claude Code 2.1.218 does not support effort "${request.effort}"`,
+      `the Claude provider protocol does not support effort "${request.effort}"`,
     );
   }
   if (request.schema !== undefined && !isRecord(request.schema)) {

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -147,4 +147,26 @@ describe("CLI configuration and doctor commands", () => {
       },
     });
   });
+
+  test("doctor readiness follows the selected provider, not unused providers", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "awsl-cli-doctor-"));
+    const cli = memoryCli(cwd, {
+      ...process.env,
+      AWSL_PROVIDER: "codex",
+      AWSL_CODEX_COMMAND: fakeCodex,
+      AWSL_FAKE_CODEX_VERSION: "0.146.1",
+      AWSL_CLAUDE_COMMAND: join(cwd, "missing-claude"),
+    });
+    expect(await executeCli(["doctor", "--format", "json"], cli.context)).toBe(
+      0,
+    );
+    expect(JSON.parse(cli.output().stdout)).toMatchObject({
+      status: "ok",
+      selectedProvider: "codex",
+      checks: {
+        codex: { available: true, version: "0.146.1", support: "unverified" },
+        claude: { available: false },
+      },
+    });
+  });
 });

--- a/tests/cli/help.test.ts
+++ b/tests/cli/help.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+
+import { executeCli } from "../../src/cli/commands.js";
+
+function memoryCli() {
+  let stdout = "";
+  let stderr = "";
+  return {
+    context: {
+      cwd: process.cwd(),
+      env: process.env,
+      homeDir: process.cwd(),
+      stdoutIsTTY: false,
+      stdin: { isTTY: true, read: async () => "" },
+      writeStdout: async (value: string) => {
+        stdout += value;
+      },
+      writeStderr: async (value: string) => {
+        stderr += value;
+      },
+    },
+    output: () => ({ stdout, stderr }),
+  };
+}
+
+describe("CLI help", () => {
+  test.each([
+    [[], "Start here:"],
+    [["help"], "Start here:"],
+    [["help", "run"], "Arguments:"],
+    [["run", "--help"], "Arguments:"],
+    [["help", "resume"], "longest valid journal prefix"],
+    [["help", "runs"], "current project"],
+    [["help", "runs", "list"], "whether interrupted work"],
+    [["help", "runs", "show"], "terminal result"],
+    [["help", "runs", "pause"], "durable confirmation"],
+    [["help", "doctor"], "without invoking a model"],
+    [["help", "config"], "Configuration precedence"],
+    [["help", "config", "show"], "per-field provenance"],
+    [["help", "workflow"], "normalized awsl Workflow ABI"],
+    [["help", "workflow", "inspect"], "No provider or model is invoked"],
+  ] as const)("renders %j successfully", async (argv, expected) => {
+    const cli = memoryCli();
+    await expect(executeCli(argv, cli.context)).resolves.toBe(0);
+    expect(cli.output().stdout).toContain(expected);
+    expect(cli.output().stderr).toBe("");
+  });
+
+  test("documents the agent-relevant run contract", async () => {
+    const cli = memoryCli();
+    expect(await executeCli(["help", "run"], cli.context)).toBe(0);
+    expect(cli.output().stdout).toContain(
+      "--args, --args-file, and non-empty piped stdin are mutually exclusive",
+    );
+    expect(cli.output().stdout).toContain("A run uses one provider");
+    expect(cli.output().stdout).toContain("awsl review.js");
+  });
+
+  test("summarizes the JavaScript Workflow ABI without external docs", async () => {
+    const cli = memoryCli();
+    expect(await executeCli(["help"], cli.context)).toBe(0);
+    expect(cli.output().stdout).toContain("export const meta");
+    expect(cli.output().stdout).toContain(
+      "args, agent, parallel, pipeline, phase, log",
+    );
+  });
+
+  test("rejects unknown nested commands even when help is requested", async () => {
+    const cli = memoryCli();
+    expect(
+      await executeCli(["runs", "frobnicate", "--help"], cli.context),
+    ).toBe(2);
+    expect(cli.output().stdout).toBe("");
+    expect(cli.output().stderr).toBe("USAGE_ERROR: invalid command line\n");
+  });
+});

--- a/tests/cli/inspect.test.ts
+++ b/tests/cli/inspect.test.ts
@@ -55,6 +55,7 @@ describe("CLI workflow inspection", () => {
       ),
     ).resolves.toBe(0);
     expect(JSON.parse(cli.output().stdout)).toMatchObject({
+      workflowAbi: "awsl-workflow@1",
       meta: { name: "basic", description: "basic workflow" },
       sha256: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
     });
@@ -81,6 +82,7 @@ describe("CLI workflow inspection", () => {
       version: 1,
       type: "command.completed",
       data: {
+        workflowAbi: "awsl-workflow@1",
         meta: { name: "basic" },
       },
     });

--- a/tests/compat/compile.test.ts
+++ b/tests/compat/compile.test.ts
@@ -34,6 +34,7 @@ describe("compileWorkflow", () => {
 
     expect(compiled).toMatchObject({
       filename: "/tmp/basic.js",
+      workflowAbi: "awsl-workflow@1",
       meta: { name: "basic", description: "basic workflow" },
       sourceHash: expect.stringMatching(/^[a-f0-9]{64}$/),
     });
@@ -69,6 +70,7 @@ describe("compileWorkflow", () => {
       description: "y",
       phases: [{ title: "A" }, { title: "B", detail: "ok", model: "shown" }],
     });
+    expect(compiled.workflowAbi).toBe("awsl-workflow@1");
   });
 
   test("accepts finite numeric literal object keys as string keys", () => {

--- a/tests/config/native-routing.test.ts
+++ b/tests/config/native-routing.test.ts
@@ -229,7 +229,7 @@ describe("native routing fingerprint input and ABI", () => {
     await expect(
       nativeRoutingFingerprint({
         ...value.input,
-        providerVersion: "0.147.0",
+        providerVersion: "0.147",
       }),
     ).rejects.toMatchObject({ code: "COMPATIBILITY_ERROR" });
     await expect(

--- a/tests/config/provider-identity.test.ts
+++ b/tests/config/provider-identity.test.ts
@@ -13,10 +13,10 @@ import { afterEach, describe, expect, test } from "vitest";
 
 import {
   type ProviderVersionProbe,
+  providerVersionSupport,
   resolveProviderIdentity,
   validateNormalizedProviderVersion,
 } from "../../src/config/provider-identity.js";
-import { AwslError } from "../../src/core/errors.js";
 
 const paths: string[] = [];
 
@@ -558,7 +558,7 @@ describe("provider identity resolution", () => {
     }
   });
 
-  test("normalizes only the exact supported trimmed banners and rejects controls, BOM, and foreign versions", async () => {
+  test("normalizes branded semantic versions without coupling runtime support to a patch release", async () => {
     const cwd = await directory();
     const codex = await executable(cwd, "codex");
     const claude = await executable(cwd, "claude");
@@ -586,9 +586,19 @@ describe("provider identity resolution", () => {
         executable: claude,
         cwd,
         env: {},
-        probe: probe("2.1.218 (Claude Code)"),
+        probe: probe("2.1.221 (Claude Code)"),
       }),
-    ).resolves.toMatchObject({ version: "2.1.218" });
+    ).resolves.toMatchObject({ version: "2.1.221" });
+
+    await expect(
+      resolveProviderIdentity({
+        provider: "codex",
+        executable: codex,
+        cwd,
+        env: {},
+        probe: probe("codex-cli 9.9.9"),
+      }),
+    ).resolves.toMatchObject({ version: "9.9.9" });
 
     await expect(
       resolveProviderIdentity({
@@ -601,9 +611,9 @@ describe("provider identity resolution", () => {
     ).rejects.toMatchObject({ code: "CONFIG_ERROR", recoverable: false });
     for (const stdout of [
       "\uFEFFcodex-cli 0.145.0",
-      "codex-cli 0.144.0",
-      "codex-cli 0.147.0",
-      "codex-cli 9.9.9",
+      "codex-cli 01.2.3",
+      "codex-cli 1.2",
+      "1.2.3 (Claude Code)",
     ]) {
       await expect(
         resolveProviderIdentity({
@@ -618,20 +628,12 @@ describe("provider identity resolution", () => {
         recoverable: false,
       });
     }
-    expect(validateNormalizedProviderVersion("codex", "0.145.0")).toBe(
-      "0.145.0",
-    );
-    expect(validateNormalizedProviderVersion("codex", "0.146.0")).toBe(
-      "0.146.0",
-    );
-    for (const version of ["0.144.0", "0.147.0", "9.9.9"]) {
-      expect(() =>
-        validateNormalizedProviderVersion("codex", version),
-      ).toThrowError(AwslError);
-    }
-    expect(() =>
-      validateNormalizedProviderVersion("claude", "9.9.9"),
-    ).toThrowError(AwslError);
+    for (const version of ["0.144.0", "0.147.0", "9.9.9"])
+      expect(validateNormalizedProviderVersion("codex", version)).toBe(version);
+    expect(validateNormalizedProviderVersion("claude", "9.9.9")).toBe("9.9.9");
+    expect(providerVersionSupport("codex", "0.146.0")).toBe("verified");
+    expect(providerVersionSupport("claude", "2.1.218")).toBe("verified");
+    expect(providerVersionSupport("claude", "2.1.221")).toBe("unverified");
   });
 
   test("applies the first-version-line byte and control rules before banner matching", async () => {

--- a/tests/config/provider-pin.test.ts
+++ b/tests/config/provider-pin.test.ts
@@ -254,7 +254,6 @@ describe("ProviderPinV1 parser", () => {
     ["noncanonical executable", pin({ executableRealpath: "/opt/../codex" })],
     ["UNC executable", pin({ executableRealpath: "//host/codex" })],
     ["raw executable version", pin({ executableVersion: "codex-cli 0.145.0" })],
-    ["foreign executable version", pin({ executableVersion: "2.1.218" })],
     ["relative cwd", pin({ canonicalCwd: "workspace" })],
     ["noncanonical cwd", pin({ canonicalCwd: "/workspace/." })],
     ["bad profile", pin({ providerProfile: "../profile" })],
@@ -771,6 +770,11 @@ describe("ProviderPinV1 resume verification", () => {
       }),
     );
   });
+
+  test("maps the legacy Claude oracle profile to the stable awsl Workflow ABI", () => {
+    const current = pinV2({ compatibilityProfile: "awsl-workflow@1" });
+    expect(verifyAndHydrateResumePin(pinV2(), current)).toEqual(current);
+  });
 });
 
 describe("ProviderPinV1 static assembly", () => {
@@ -781,7 +785,7 @@ describe("ProviderPinV1 static assembly", () => {
     expect(built).toMatchObject({
       version: 2,
       provider: "codex",
-      compatibilityProfile: "claude-code@2.1.218",
+      compatibilityProfile: "awsl-workflow@1",
       executableRealpath: "/opt/awsl/codex",
       executableVersion: "0.145.0",
       explicitDefaultModel: "gpt-5.6-terra",

--- a/tests/core/contracts.test.ts
+++ b/tests/core/contracts.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "vitest";
 
-import { AwslError, COMPAT_PROFILE, createEvent } from "../../src/index.js";
+import {
+  AwslError,
+  COMPAT_PROFILE,
+  WORKFLOW_ABI,
+  createEvent,
+} from "../../src/index.js";
 
 describe("public contracts", () => {
-  test("exports a versioned compatibility profile", () => {
+  test("adds the stable Workflow ABI without changing the legacy public profile", () => {
     expect(COMPAT_PROFILE).toMatchObject({
       id: "claude-code@2.1.218",
       agentCap: 1000,
@@ -13,6 +18,11 @@ describe("public contracts", () => {
         stderrTailBytes: 64 * 1024,
         killGraceMs: 1_000,
       },
+    });
+    expect(WORKFLOW_ABI).toMatchObject({
+      id: "awsl-workflow@1",
+      agentCap: COMPAT_PROFILE.agentCap,
+      structuredOutputAttempts: COMPAT_PROFILE.structuredOutputAttempts,
     });
   });
 

--- a/tests/package/install-smoke.test.ts
+++ b/tests/package/install-smoke.test.ts
@@ -339,11 +339,11 @@ test("packed CLI installs and runs from a clean directory", async () => {
       [
         "--input-type=module",
         "--eval",
-        'import("@xhinliang/awsl").then((value) => process.stdout.write(value.COMPAT_PROFILE.id))',
+        'import("@xhinliang/awsl").then((value) => process.stdout.write(value.WORKFLOW_ABI.id))',
       ],
       { cwd: project, timeout: 20_000 },
     );
-    expect(library.stdout).toBe("claude-code@2.1.218");
+    expect(library.stdout).toBe("awsl-workflow@1");
   } finally {
     await rm(root, { force: true, recursive: true });
   }

--- a/tests/providers/claude.test.ts
+++ b/tests/providers/claude.test.ts
@@ -420,10 +420,14 @@ describe("Claude adapter request contract", () => {
     expect(
       () => new ClaudeAdapter({ identity: { ...identity, id: "codex" } }),
     ).toThrow(/requires a claude provider identity/);
+    expect(
+      new ClaudeAdapter({ identity: { ...identity, version: "2.1.221" } })
+        .identity.version,
+    ).toBe("2.1.221");
   });
 
-  test("rejects a raw or foreign provider version before launch", () => {
-    for (const version of ["2.1.218 (Claude Code)", "9.9.9"]) {
+  test("rejects a raw or malformed provider version before launch", () => {
+    for (const version of ["2.1.218 (Claude Code)", "9.9"]) {
       let launchCalls = 0;
       expect(() => {
         const provider = new ClaudeAdapter({

--- a/tests/providers/codex.test.ts
+++ b/tests/providers/codex.test.ts
@@ -407,8 +407,8 @@ describe("Codex adapter contract", () => {
       "COMPATIBILITY_ERROR",
     ],
     [
-      "foreign normalized version",
-      { ...identity, version: "9.9.9" },
+      "malformed normalized version",
+      { ...identity, version: "9.9" },
       "COMPATIBILITY_ERROR",
     ],
   ] as const)(


### PR DESCRIPTION
## Summary

- define `awsl-workflow@1` as the runtime-owned Workflow ABI while retaining the original Claude Code 2.1.218 profile as oracle evidence and a legacy public contract
- accept strictly branded Codex and Claude semantic versions, classify versions as `verified` or `unverified`, and base `doctor` readiness on the selected provider
- preserve exact executable-version pinning for resume and map durable 0.1.x provider pins onto the new Workflow ABI
- make CLI help self-contained with workflow globals, safe invocation order, input and output contracts, examples, nested help paths, and correct exit codes
- add `workflowAbi` to workflow inspection and update compatibility documentation

## Test

- `pnpm run check`
- `pnpm run test` — 995 passed, 1 skipped
- `pnpm run test:package` — 7 passed
- `pnpm run test:conformance` — 4 passed
- `pnpm run sbom`
- `git diff --check`
- manual built-CLI checks for top-level help, nested help, unknown nested commands, `doctor --format json`, and `workflow inspect --format json`

No model was invoked for the manual acceptance checks.

## Risk

- New provider versions are accepted as `unverified`; this removes false patch-version incompatibility but does not certify an unchanged provider protocol. Adapter argument validation and event parsing continue to fail closed.
- Resume still requires the exact pinned provider executable path and version. Legacy `claude-code@2.1.218` pins are accepted only as the predecessor of `awsl-workflow@1` with the existing behavior fingerprint intact.
- `doctor` changes aggregate status to follow the selected provider and adds `selectedProvider` plus per-provider `support`; `workflow inspect` adds `workflowAbi`. Existing JSON fields and CLI arguments remain unchanged.
