### PR TITLE
release: Prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 0.2.0 - 2026-08-06
 
 ### Added
 
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 - Make `awsl help`, nested help paths, and an empty invocation exit successfully,
   while rejecting unknown nested commands instead of showing misleading help.
+- Update the transitive `fast-uri` dependency to the patched `3.1.5` release.
 
 ## 0.1.1 - 2026-07-30
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xhinliang/awsl",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Durable JavaScript workflows for coding agents — Codex or Claude, with parallelism, resume, budgets, and Git worktrees",
   "keywords": [
     "agentic-workflows",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,8 +494,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -951,7 +951,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -1016,7 +1016,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -4,11 +4,11 @@
   "version": 1,
   "metadata": {
     "component": {
-      "bom-ref": "pkg:npm/%40xhinliang/awsl@0.1.1",
+      "bom-ref": "pkg:npm/%40xhinliang/awsl@0.2.0",
       "type": "application",
       "name": "@xhinliang/awsl",
-      "version": "0.1.1",
-      "purl": "pkg:npm/%40xhinliang/awsl@0.1.1",
+      "version": "0.2.0",
+      "purl": "pkg:npm/%40xhinliang/awsl@0.2.0",
       "licenses": [
         {
           "license": {
@@ -20,7 +20,7 @@
     "properties": [
       {
         "name": "awsl:lockfile:sha256",
-        "value": "881eb6807eb51dc9b2ba246defb213f81675013e7f7787b911812903da973880"
+        "value": "589321594aff5b3ed9e56e3879a634d7fe93bc4000ad1c93d64348a6be52be24"
       }
     ]
   },
@@ -104,15 +104,15 @@
       ]
     },
     {
-      "bom-ref": "pkg:npm/fast-uri@3.1.4",
+      "bom-ref": "pkg:npm/fast-uri@3.1.5",
       "type": "library",
       "name": "fast-uri",
-      "version": "3.1.4",
-      "purl": "pkg:npm/fast-uri@3.1.4",
+      "version": "3.1.5",
+      "purl": "pkg:npm/fast-uri@3.1.5",
       "hashes": [
         {
           "alg": "SHA-512",
-          "content": "f099db910e23b83caf62ce26805190aa0e32098b450ed52d9a9d90210ab5d5965ee42150e7072a9b5aea0e0021fd074cc92b819cfccc5222543591b937f02243"
+          "content": "807c00d4ef4b0c870aba730a84e6d2fc78a6c2d7a13b59cf50408a02ee53a4a81a3b5f5f716125e1b96259ed635b1545bc85f3b498e34382fc5d0d4453d7fb27"
         }
       ]
     },
@@ -171,7 +171,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40xhinliang/awsl@0.1.1",
+      "ref": "pkg:npm/%40xhinliang/awsl@0.2.0",
       "dependsOn": [
         "pkg:npm/acorn-walk@8.3.5",
         "pkg:npm/acorn@8.17.0",
@@ -202,7 +202,7 @@
       "ref": "pkg:npm/ajv@8.20.0",
       "dependsOn": [
         "pkg:npm/fast-deep-equal@3.1.3",
-        "pkg:npm/fast-uri@3.1.4",
+        "pkg:npm/fast-uri@3.1.5",
         "pkg:npm/json-schema-traverse@1.0.0",
         "pkg:npm/require-from-string@2.0.2"
       ]
@@ -216,7 +216,7 @@
       "dependsOn": []
     },
     {
-      "ref": "pkg:npm/fast-uri@3.1.4",
+      "ref": "pkg:npm/fast-uri@3.1.5",
       "dependsOn": []
     },
     {

--- a/tests/package/sbom.test.ts
+++ b/tests/package/sbom.test.ts
@@ -102,7 +102,7 @@ test("generates a deterministic production-only CycloneDX SBOM", async () => {
       "ajv@8.20.0",
       "commander@13.1.0",
       "fast-deep-equal@3.1.3",
-      "fast-uri@3.1.4",
+      "fast-uri@3.1.5",
       "json-schema-traverse@1.0.0",
       "require-from-string@2.0.2",
       "smol-toml@1.7.1",


### PR DESCRIPTION
## Summary

- prepare @xhinliang/awsl 0.2.0 from the current main branch
- release the workflow ABI and provider-version decoupling so Codex 0.146.1 and Claude Code 2.1.221 are accepted as unverified instead of blocked
- update transitive fast-uri from 3.1.4 to patched 3.1.5 and regenerate the CycloneDX SBOM

## Test

- pnpm run check
- pnpm run test: 995 passed, 1 skipped
- pnpm run test:package: 7 passed
- pnpm run test:conformance: 4 passed
- pnpm audit --audit-level high: no known vulnerabilities
- npm pack --dry-run: @xhinliang/awsl 0.2.0

## Risk

- newer provider versions remain explicitly marked unverified; exact provider-version resume pins are preserved
- the release workflow still requires the GitHub tag to exactly match package.json
