### PR TITLE
release: prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 0.3.0 - 2026-08-19
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xhinliang/awsl",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Codex-verified, Claude-compatible durable local runtime for Claude Code Workflow JS, with resume, checkpoints, budgets, and Git worktrees",
   "keywords": [
     "agentic-workflows",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -4,11 +4,11 @@
   "version": 1,
   "metadata": {
     "component": {
-      "bom-ref": "pkg:npm/%40xhinliang/awsl@0.2.0",
+      "bom-ref": "pkg:npm/%40xhinliang/awsl@0.3.0",
       "type": "application",
       "name": "@xhinliang/awsl",
-      "version": "0.2.0",
-      "purl": "pkg:npm/%40xhinliang/awsl@0.2.0",
+      "version": "0.3.0",
+      "purl": "pkg:npm/%40xhinliang/awsl@0.3.0",
       "licenses": [
         {
           "license": {
@@ -171,7 +171,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40xhinliang/awsl@0.2.0",
+      "ref": "pkg:npm/%40xhinliang/awsl@0.3.0",
       "dependsOn": [
         "pkg:npm/acorn-walk@8.3.5",
         "pkg:npm/acorn@8.17.0",


### PR DESCRIPTION
## Summary

- prepare `@xhinliang/awsl` v0.3.0
- close the changelog section for 2026-08-19
- regenerate the CycloneDX SBOM with the release version

## Verification

- `pnpm run check`
- `pnpm run test` (1028 passed, 1 skipped)
- `pnpm run test:package` (7 passed)
- `pnpm run test:conformance` (4 passed)
- `pnpm audit --audit-level high`
- `npm pack --dry-run`
- `git diff --check`
