### PR TITLE
release: Prepare v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.3.1 - 2026-08-20
+
+### Changed
+
+- Route the default Codex `fast` tier to `gpt-5.6-luna` at low reasoning
+  effort, while preserving the existing Claude Haiku, Codex balanced, and
+  Codex strong mappings.
+
 ## 0.3.0 - 2026-08-19
 
 ### Added
@@ -28,10 +36,6 @@ All notable changes to this project will be documented in this file.
   lifecycle events.
 
 ### Changed
-
-- Route the default Codex `fast` tier to `gpt-5.6-luna` at low reasoning
-  effort, while preserving the existing Claude Haiku, Codex balanced, and
-  Codex strong mappings.
 
 - Position awsl as the Agent Workflow State Layer: a Codex-verified, durable
   local runtime for compatible Claude Code Workflows, while keeping

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xhinliang/awsl",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Codex-verified, Claude-compatible durable local runtime for Claude Code Workflow JS, with resume, checkpoints, budgets, and Git worktrees",
   "keywords": [
     "agentic-workflows",

--- a/sbom.cdx.json
+++ b/sbom.cdx.json
@@ -4,11 +4,11 @@
   "version": 1,
   "metadata": {
     "component": {
-      "bom-ref": "pkg:npm/%40xhinliang/awsl@0.3.0",
+      "bom-ref": "pkg:npm/%40xhinliang/awsl@0.3.1",
       "type": "application",
       "name": "@xhinliang/awsl",
-      "version": "0.3.0",
-      "purl": "pkg:npm/%40xhinliang/awsl@0.3.0",
+      "version": "0.3.1",
+      "purl": "pkg:npm/%40xhinliang/awsl@0.3.1",
       "licenses": [
         {
           "license": {
@@ -171,7 +171,7 @@
   ],
   "dependencies": [
     {
-      "ref": "pkg:npm/%40xhinliang/awsl@0.3.0",
+      "ref": "pkg:npm/%40xhinliang/awsl@0.3.1",
       "dependsOn": [
         "pkg:npm/acorn-walk@8.3.5",
         "pkg:npm/acorn@8.17.0",


### PR DESCRIPTION
## Summary

Prepare `@xhinliang/awsl@0.3.1` for publication.

## Verification

- [x] `pnpm run check`
- [x] `pnpm run test` — 1,028 passed, 1 skipped
- [x] `pnpm run build`
- [x] `pnpm run test:package` — 7 passed
- [x] `pnpm run test:conformance` — 4 passed (feature revision; release changes are metadata only)
- [x] `pnpm run sbom`
- [x] `git diff --check`

## Compatibility and risk

- Patch release containing the Codex fast-tier routing change from #14.
- No public CLI, Workflow ABI, event, durable-state, permission, redaction, or
  worktree contract changes.
- The model-map fingerprint intentionally prevents resume across the routing
  change.

## Release

After merge, publish GitHub Release `v0.3.1` at the merge commit. The OIDC
release workflow will verify tag/package identity and publish npm provenance.
